### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pynetdicom3/ACSEprovider.py
+++ b/pynetdicom3/ACSEprovider.py
@@ -241,12 +241,10 @@ class ACSEServiceProvider(object):
         """
         # Check valid Result and Source values
         if result not in [0x01, 0x02]:
-            raise ValueError("ACSE rejection: invalid Result value '%s'"
-                             %result)
+            raise ValueError("ACSE rejection: invalid Result value '{0!s}'".format(result))
 
         if source not in [0x01, 0x02, 0x03]:
-            raise ValueError("ACSE rejection: invalid Source value '%s'"
-                             %source)
+            raise ValueError("ACSE rejection: invalid Source value '{0!s}'".format(source))
 
         # Send an A-ASSOCIATE primitive, rejecting the association
         assoc_primitive.presentation_context_definition_list = []
@@ -356,10 +354,10 @@ class ACSEServiceProvider(object):
             elif reason in [0x00, 0x01, 0x02, 0x04, 0x05, 0x06]:
                 assoc_abort.reason = reason
             else:
-                raise ValueError("ACSE.Abort() invalid reason '%s'" %reason)
+                raise ValueError("ACSE.Abort() invalid reason '{0!s}'".format(reason))
 
         else:
-            raise ValueError("ACSE.Abort() invalid source '%s'" %source)
+            raise ValueError("ACSE.Abort() invalid source '{0!s}'".format(source))
 
         self.DUL.Send(assoc_abort)
         time.sleep(0.5)
@@ -426,16 +424,12 @@ class ACSEServiceProvider(object):
         s.append('====================== BEGIN A-ASSOCIATE-RQ ================'
                  '=====')
 
-        s.append('Our Implementation Class UID:      %s'
-                 %user_info.implementation_class_uid)
-        s.append('Our Implementation Version Name:   %s'
-                 %user_info.implementation_version_name)
-        s.append('Application Context Name:    %s' %app_context)
-        s.append('Calling Application Name:    %s'
-                 %assoc_rq.calling_ae_title.decode('utf-8'))
-        s.append('Called Application Name:     %s'
-                 %assoc_rq.called_ae_title.decode('utf-8'))
-        s.append('Our Max PDU Receive Size:    %s' %user_info.maximum_length)
+        s.append('Our Implementation Class UID:      {0!s}'.format(user_info.implementation_class_uid))
+        s.append('Our Implementation Version Name:   {0!s}'.format(user_info.implementation_version_name))
+        s.append('Application Context Name:    {0!s}'.format(app_context))
+        s.append('Calling Application Name:    {0!s}'.format(assoc_rq.calling_ae_title.decode('utf-8')))
+        s.append('Called Application Name:     {0!s}'.format(assoc_rq.called_ae_title.decode('utf-8')))
+        s.append('Our Max PDU Receive Size:    {0!s}'.format(user_info.maximum_length))
 
         ## Presentation Contexts
         if len(pres_contexts) == 1:
@@ -444,14 +438,14 @@ class ACSEServiceProvider(object):
             s.append('Presentation Contexts:')
 
         for context in pres_contexts:
-            s.append('  Context ID:        %s (Proposed)' %(context.ID))
-            s.append('    Abstract Syntax: =%s' %context.abstract_syntax)
+            s.append('  Context ID:        {0!s} (Proposed)'.format((context.ID)))
+            s.append('    Abstract Syntax: ={0!s}'.format(context.abstract_syntax))
 
             if 'SCU' in context.__dict__.keys():
-                scp_scu_role = '%s/%s' %(context.SCP, context.SCU)
+                scp_scu_role = '{0!s}/{1!s}'.format(context.SCP, context.SCU)
             else:
                 scp_scu_role = 'Default'
-            s.append('    Proposed SCP/SCU Role: %s' %scp_scu_role)
+            s.append('    Proposed SCP/SCU Role: {0!s}'.format(scp_scu_role))
 
             # Transfer Syntaxes
             if len(context.transfer_syntax) == 1:
@@ -460,7 +454,7 @@ class ACSEServiceProvider(object):
                 s.append('    Proposed Transfer Syntaxes:')
 
             for ts in context.transfer_syntax:
-                s.append('      =%s' %ts.name)
+                s.append('      ={0!s}'.format(ts.name))
 
         ## Extended Negotiation
         if assoc_rq.user_information.ext_neg is not None:
@@ -468,13 +462,13 @@ class ACSEServiceProvider(object):
 
             for item in assoc_rq.user_information.ext_neg:
 
-                s.append('  Abstract Syntax: =%s' %item.UID)
+                s.append('  Abstract Syntax: ={0!s}'.format(item.UID))
                 #s.append('    Application Information, length: %d bytes' %len(item.app_info))
                 app_info = wrap_list(item.app_info)
                 app_info[0] = '[' + app_info[0][1:]
                 app_info[-1] = app_info[-1] + ' ]'
                 for line in app_info:
-                    s.append('    %s' %line)
+                    s.append('    {0!s}'.format(line))
         else:
             s.append('Requested Extended Negotiation: None')
 
@@ -484,13 +478,13 @@ class ACSEServiceProvider(object):
 
             for item in assoc_rq.user_information.common_ext_neg:
 
-                s.append('  Abstract Syntax: =%s' %item.sop_class_uid)
-                s.append('  Service Class:   =%s' %item.service_class_uid)
+                s.append('  Abstract Syntax: ={0!s}'.format(item.sop_class_uid))
+                s.append('  Service Class:   ={0!s}'.format(item.service_class_uid))
 
                 if item.related_general_sop_class_identification != []:
                     s.append('  Related General SOP Class(es):')
                     for sub_field in item.related_general_sop_class_identification:
-                        s.append('    =%s' %sub_field)
+                        s.append('    ={0!s}'.format(sub_field))
                 else:
                     s.append('  Related General SOP Classes: None')
         else:
@@ -500,19 +494,17 @@ class ACSEServiceProvider(object):
         if user_info.user_identity is not None:
             usid = user_info.user_identity
             s.append('Requested User Identity Negotiation:')
-            s.append('  Authentication Mode: %d - %s' %(usid.id_type,
+            s.append('  Authentication Mode: {0:d} - {1!s}'.format(usid.id_type,
                                                         usid.id_type_str))
             if usid.id_type == 1:
-                s.append('  Username: [%s]' %usid.primary.decode('utf-8'))
+                s.append('  Username: [{0!s}]'.format(usid.primary.decode('utf-8')))
             elif usid.id_type == 2:
-                s.append('  Username: [%s]' %usid.primary.decode('utf-8'))
-                s.append('  Password: [%s]' %usid.secondary.decode('utf-8'))
+                s.append('  Username: [{0!s}]'.format(usid.primary.decode('utf-8')))
+                s.append('  Password: [{0!s}]'.format(usid.secondary.decode('utf-8')))
             elif usid.id_type == 3:
-                s.append('  Kerberos Service Ticket (not dumped) length: %d'
-                         %len(usid.primary))
+                s.append('  Kerberos Service Ticket (not dumped) length: {0:d}'.format(len(usid.primary)))
             elif usid.id_type == 4:
-                s.append('  SAML Assertion (not dumped) length: %d'
-                         %len(usid.primary))
+                s.append('  SAML Assertion (not dumped) length: {0:d}'.format(len(usid.primary)))
 
             if usid.response_requested:
                 s.append('  Positive Response requested: Yes')
@@ -553,40 +545,37 @@ class ACSEServiceProvider(object):
         s.append('====================== BEGIN A-ASSOCIATE-AC ================'
                  '=====')
 
-        s.append('Our Implementation Class UID:      %s'
-                 %user_info.implementation_class_uid)
-        s.append('Our Implementation Version Name:   %s'
-                 %user_info.implementation_version_name)
-        s.append('Application Context Name:    %s' %app_context)
-        s.append('Responding Application Name: %s' %responding_ae)
-        s.append('Our Max PDU Receive Size:    %s' %user_info.maximum_length)
+        s.append('Our Implementation Class UID:      {0!s}'.format(user_info.implementation_class_uid))
+        s.append('Our Implementation Version Name:   {0!s}'.format(user_info.implementation_version_name))
+        s.append('Application Context Name:    {0!s}'.format(app_context))
+        s.append('Responding Application Name: {0!s}'.format(responding_ae))
+        s.append('Our Max PDU Receive Size:    {0!s}'.format(user_info.maximum_length))
         s.append('Presentation Contexts:')
 
         for item in pres_contexts:
-            s.append('  Context ID:        %s (%s)' %(item.ID, item.result_str))
+            s.append('  Context ID:        {0!s} ({1!s})'.format(item.ID, item.result_str))
 
             # If Presentation Context was accepted
             if item.result == 0:
                 if item.SCP is None and item.SCU is None:
                     ac_scp_scu_role = 'Default'
                 else:
-                    ac_scp_scu_role = '%s/%s' %(item.SCP, item.SCU)
-                s.append('    Accepted SCP/SCU Role: %s' %ac_scp_scu_role)
-                s.append('    Accepted Transfer Syntax: =%s'
-                         %item.transfer_syntax)
+                    ac_scp_scu_role = '{0!s}/{1!s}'.format(item.SCP, item.SCU)
+                s.append('    Accepted SCP/SCU Role: {0!s}'.format(ac_scp_scu_role))
+                s.append('    Accepted Transfer Syntax: ={0!s}'.format(item.transfer_syntax))
 
         ## Extended Negotiation
         ext_nego = 'None'
         #if assoc_ac.UserInformation.ExtendedNegotiation is not None:
         #    ext_nego = 'Yes'
-        s.append('Accepted Extended Negotiation: %s' %ext_nego)
+        s.append('Accepted Extended Negotiation: {0!s}'.format(ext_nego))
 
         ## User Identity Negotiation
         usr_id = 'None'
         if user_info.user_identity is not None:
             usr_id = 'Yes'
 
-        s.append('User Identity Negotiation Response:  %s' %usr_id)
+        s.append('User Identity Negotiation Response:  {0!s}'.format(usr_id))
         s.append('======================= END A-ASSOCIATE-AC =================='
                  '====')
 
@@ -701,30 +690,28 @@ class ACSEServiceProvider(object):
         s = ['Request Parameters:']
         s.append('====================== BEGIN A-ASSOCIATE-RQ ================'
                  '=====')
-        s.append('Their Implementation Class UID:    %s' %their_class_uid)
-        s.append('Their Implementation Version Name: %s' %their_version)
-        s.append('Application Context Name:    %s' %app_context)
-        s.append('Calling Application Name:    %s'
-                 %assoc_rq.calling_ae_title.decode('utf-8'))
-        s.append('Called Application Name:     %s'
-                 %assoc_rq.called_ae_title.decode('utf-8'))
-        s.append('Their Max PDU Receive Size:  %s' %user_info.maximum_length)
+        s.append('Their Implementation Class UID:    {0!s}'.format(their_class_uid))
+        s.append('Their Implementation Version Name: {0!s}'.format(their_version))
+        s.append('Application Context Name:    {0!s}'.format(app_context))
+        s.append('Calling Application Name:    {0!s}'.format(assoc_rq.calling_ae_title.decode('utf-8')))
+        s.append('Called Application Name:     {0!s}'.format(assoc_rq.called_ae_title.decode('utf-8')))
+        s.append('Their Max PDU Receive Size:  {0!s}'.format(user_info.maximum_length))
 
         ## Presentation Contexts
         s.append('Presentation Contexts:')
         for item in pres_contexts:
-            s.append('  Context ID:        %s (Proposed)' %item.ID)
-            s.append('    Abstract Syntax: =%s' %item.abstract_syntax)
+            s.append('  Context ID:        {0!s} (Proposed)'.format(item.ID))
+            s.append('    Abstract Syntax: ={0!s}'.format(item.abstract_syntax))
 
             if item.SCU is None and item.SCP is None:
                 scp_scu_role = 'Default'
             else:
-                scp_scu_role = '%s/%s' %(item.SCP, item.SCU)
+                scp_scu_role = '{0!s}/{1!s}'.format(item.SCP, item.SCU)
 
-            s.append('    Proposed SCP/SCU Role: %s' %scp_scu_role)
+            s.append('    Proposed SCP/SCU Role: {0!s}'.format(scp_scu_role))
             s.append('    Proposed Transfer Syntax(es):')
             for ts in item.transfer_syntax:
-                s.append('      =%s' %ts)
+                s.append('      ={0!s}'.format(ts))
 
         ## Extended Negotiation
         if assoc_rq.user_information.ext_neg is not None:
@@ -732,13 +719,13 @@ class ACSEServiceProvider(object):
 
             for item in assoc_rq.user_information.ext_neg:
 
-                s.append('  Abstract Syntax: =%s' %item.UID)
+                s.append('  Abstract Syntax: ={0!s}'.format(item.UID))
                 #s.append('    Application Information, length: %d bytes' %len(item.app_info))
                 app_info = wrap_list(item.app_info)
                 app_info[0] = '[' + app_info[0][1:]
                 app_info[-1] = app_info[-1] + ' ]'
                 for line in app_info:
-                    s.append('    %s' %line)
+                    s.append('    {0!s}'.format(line))
         else:
             s.append('Requested Extended Negotiation: None')
 
@@ -748,13 +735,13 @@ class ACSEServiceProvider(object):
 
             for item in assoc_rq.user_information.common_ext_neg:
 
-                s.append('  Abstract Syntax: =%s' %item.sop_class_uid)
-                s.append('  Service Class:   =%s' %item.service_class_uid)
+                s.append('  Abstract Syntax: ={0!s}'.format(item.sop_class_uid))
+                s.append('  Service Class:   ={0!s}'.format(item.service_class_uid))
 
                 if item.related_general_sop_class_identification != []:
                     s.append('  Related General SOP Class(es):')
                     for sub_field in item.related_general_sop_class_identification:
-                        s.append('    =%s' %sub_field)
+                        s.append('    ={0!s}'.format(sub_field))
                 else:
                     s.append('  Related General SOP Classes: None')
         else:
@@ -772,19 +759,17 @@ class ACSEServiceProvider(object):
         if user_info.user_identity is not None:
             usid = user_info.user_identity
             s.append('Requested User Identity Negotiation:')
-            s.append('  Authentication Mode: %d - %s' %(usid.id_type,
+            s.append('  Authentication Mode: {0:d} - {1!s}'.format(usid.id_type,
                                                         usid.id_type_str))
             if usid.id_type == 1:
-                s.append('  Username: [%s]' %usid.primary.decode('utf-8'))
+                s.append('  Username: [{0!s}]'.format(usid.primary.decode('utf-8')))
             elif usid.id_type == 2:
-                s.append('  Username: [%s]' %usid.primary.decode('utf-8'))
-                s.append('  Password: [%s]' %usid.secondary.decode('utf-8'))
+                s.append('  Username: [{0!s}]'.format(usid.primary.decode('utf-8')))
+                s.append('  Password: [{0!s}]'.format(usid.secondary.decode('utf-8')))
             elif usid.id_type == 3:
-                s.append('  Kerberos Service Ticket (not dumped) length: %d'
-                         %len(usid.primary))
+                s.append('  Kerberos Service Ticket (not dumped) length: {0:d}'.format(len(usid.primary)))
             elif usid.id_type == 4:
-                s.append('  SAML Assertion (not dumped) length: %d'
-                         %len(usid.primary))
+                s.append('  SAML Assertion (not dumped) length: {0:d}'.format(len(usid.primary)))
 
             if usid.response_requested:
                 s.append('  Positive Response requested: Yes')
@@ -832,51 +817,47 @@ class ACSEServiceProvider(object):
         s.append('====================== BEGIN A-ASSOCIATE-AC ================'
                  '=====')
 
-        s.append('Their Implementation Class UID:    %s' %their_class_uid)
-        s.append('Their Implementation Version Name: %s' %their_version)
-        s.append('Application Context Name:    %s' %app_context)
-        s.append('Calling Application Name:    %s'
-                 %assoc_ac.calling_ae_title.decode('utf-8'))
-        s.append('Called Application Name:     %s'
-                 %assoc_ac.called_ae_title.decode('utf-8'))
-        s.append('Their Max PDU Receive Size:  %s' %user_info.maximum_length)
+        s.append('Their Implementation Class UID:    {0!s}'.format(their_class_uid))
+        s.append('Their Implementation Version Name: {0!s}'.format(their_version))
+        s.append('Application Context Name:    {0!s}'.format(app_context))
+        s.append('Calling Application Name:    {0!s}'.format(assoc_ac.calling_ae_title.decode('utf-8')))
+        s.append('Called Application Name:     {0!s}'.format(assoc_ac.called_ae_title.decode('utf-8')))
+        s.append('Their Max PDU Receive Size:  {0!s}'.format(user_info.maximum_length))
         s.append('Presentation Contexts:')
 
         for item in pres_contexts:
-            s.append('  Context ID:        %s (%s)' %(item.ID, item.result_str))
+            s.append('  Context ID:        {0!s} ({1!s})'.format(item.ID, item.result_str))
 
             if item.result == 0:
                 if item.SCP is None and item.SCU is None:
                     ac_scp_scu_role = 'Default'
                     rq_scp_scu_role = 'Default'
                 else:
-                    ac_scp_scu_role = '%s/%s' %(item.SCP, item.SCU)
-                s.append('    Proposed SCP/SCU Role: %s' %rq_scp_scu_role)
-                s.append('    Accepted SCP/SCU Role: %s' %ac_scp_scu_role)
-                s.append('    Accepted Transfer Syntax: =%s'
-                         %item.transfer_syntax)
+                    ac_scp_scu_role = '{0!s}/{1!s}'.format(item.SCP, item.SCU)
+                s.append('    Proposed SCP/SCU Role: {0!s}'.format(rq_scp_scu_role))
+                s.append('    Accepted SCP/SCU Role: {0!s}'.format(ac_scp_scu_role))
+                s.append('    Accepted Transfer Syntax: ={0!s}'.format(item.transfer_syntax))
 
         ## Extended Negotiation
         ext_neg = 'None'
         #if assoc_ac.UserInformation.ExtendedNegotiation is not None:
         #    ext_nego = 'Yes'
-        s.append('Accepted Extended Negotiation: %s' %ext_neg)
+        s.append('Accepted Extended Negotiation: {0!s}'.format(ext_neg))
 
         ## Common Extended Negotiation
         common_ext_neg = 'None'
-        s.append('Accepted Common Extended Negotiation: %s' %common_ext_neg)
+        s.append('Accepted Common Extended Negotiation: {0!s}'.format(common_ext_neg))
 
         ## Asynchronous Operations Negotiation
         async_neg = 'None'
-        s.append('Accepted Asynchronous Operations Window Negotiation: %s'
-                 %async_neg)
+        s.append('Accepted Asynchronous Operations Window Negotiation: {0!s}'.format(async_neg))
 
         ## User Identity
         usr_id = 'None'
         if user_info.user_identity is not None:
             usr_id = 'Yes'
 
-        s.append('User Identity Negotiation Response:  %s' %usr_id)
+        s.append('User Identity Negotiation Response:  {0!s}'.format(usr_id))
         s.append('======================= END A-ASSOCIATE-AC =================='
                  '====')
 
@@ -901,9 +882,9 @@ class ACSEServiceProvider(object):
         s = ['Reject Parameters:']
         s.append('====================== BEGIN A-ASSOCIATE-RJ ================'
                  '=====')
-        s.append('Result:    %s' %assoc_rj.result_str)
-        s.append('Source:    %s' %assoc_rj.source_str)
-        s.append('Reason:    %s' %assoc_rj.reason_str)
+        s.append('Result:    {0!s}'.format(assoc_rj.result_str))
+        s.append('Source:    {0!s}'.format(assoc_rj.source_str))
+        s.append('Reason:    {0!s}'.format(assoc_rj.reason_str))
         s.append('======================= END A-ASSOCIATE-RJ =================='
                  '====')
         for line in s:
@@ -979,8 +960,8 @@ class ACSEServiceProvider(object):
         s = ['Abort Parameters:']
         s.append('========================== BEGIN A-ABORT ===================='
                  '=====')
-        s.append('Abort Source: %s' %a_abort.source_str)
-        s.append('Abort Reason: %s' %a_abort.reason_str)
+        s.append('Abort Source: {0!s}'.format(a_abort.source_str))
+        s.append('Abort Reason: {0!s}'.format(a_abort.reason_str))
         s.append('=========================== END A-ABORT ====================='
                  '====')
         for line in s:

--- a/pynetdicom3/DIMSEprovider.py
+++ b/pynetdicom3/DIMSEprovider.py
@@ -451,13 +451,12 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== OUTGOING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-STORE RQ')
-        s.append('Message ID                    : %s' %ds.MessageID)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Affected SOP Instance UID     : %s'
-                 %ds.AffectedSOPInstanceUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('Priority                      : %s' %priority)
+        s.append('Message Type                  : {0!s}'.format('C-STORE RQ'))
+        s.append('Message ID                    : {0!s}'.format(ds.MessageID))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Affected SOP Instance UID     : {0!s}'.format(ds.AffectedSOPInstanceUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('Priority                      : {0!s}'.format(priority))
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
         for line in s:
@@ -493,12 +492,12 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== OUTGOING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-FIND RQ')
-        s.append('Presentation Context ID       : %s' %dimse_msg.ID)
-        s.append('Message ID                    : %s' %ds.MessageID)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('Priority                      : %s' %priority)
+        s.append('Message Type                  : {0!s}'.format('C-FIND RQ'))
+        s.append('Presentation Context ID       : {0!s}'.format(dimse_msg.ID))
+        s.append('Message ID                    : {0!s}'.format(ds.MessageID))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('Priority                      : {0!s}'.format(priority))
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
 
@@ -521,12 +520,11 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== OUTGOING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-FIND RSP')
-        s.append('Message ID Being Responded To : %s'
-                 %ds.MessageIDBeingRespondedTo)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('DIMSE Status                  : 0x%04x' %ds.Status)
+        s.append('Message Type                  : {0!s}'.format('C-FIND RSP'))
+        s.append('Message ID Being Responded To : {0!s}'.format(ds.MessageIDBeingRespondedTo))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('DIMSE Status                  : 0x{0:04x}'.format(ds.Status))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
@@ -567,11 +565,11 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== OUTGOING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-GET RQ')
-        s.append('Message ID                    : %s' %ds.MessageID)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('Priority                      : %s' %priority)
+        s.append('Message Type                  : {0!s}'.format('C-GET RQ'))
+        s.append('Message ID                    : {0!s}'.format(ds.MessageID))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('Priority                      : {0!s}'.format(priority))
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
         for line in s:
@@ -593,12 +591,11 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== OUTGOING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-GET RSP')
-        s.append('Message ID Being Responded To : %s'
-                 %ds.MessageIDBeingRespondedTo)
+        s.append('Message Type                  : {0!s}'.format('C-GET RSP'))
+        s.append('Message ID Being Responded To : {0!s}'.format(ds.MessageIDBeingRespondedTo))
         s.append('Affected SOP Class UID        : none')
-        s.append('Data Set                      : %s' %dataset)
-        s.append('DIMSE Status                  : 0x%04x' %ds.Status)
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('DIMSE Status                  : 0x{0:04x}'.format(ds.Status))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
@@ -629,13 +626,12 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== OUTGOING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-MOVE RQ')
-        s.append('Message ID                    : %s' %ds.MessageID)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Move Destination              : %s'
-                 %ds.MoveDestination.decode('utf-8'))
-        s.append('Data Set                      : %s' %dataset)
-        s.append('Priority                      : %s' %priority)
+        s.append('Message Type                  : {0!s}'.format('C-MOVE RQ'))
+        s.append('Message ID                    : {0!s}'.format(ds.MessageID))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Move Destination              : {0!s}'.format(ds.MoveDestination.decode('utf-8')))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('Priority                      : {0!s}'.format(priority))
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
         for line in s:
@@ -658,12 +654,11 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== OUTGOING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-MOVE RSP')
-        s.append('Message ID Being Responded To : %s'
-                 %ds.MessageIDBeingRespondedTo)
+        s.append('Message Type                  : {0!s}'.format('C-MOVE RSP'))
+        s.append('Message ID Being Responded To : {0!s}'.format(ds.MessageIDBeingRespondedTo))
         s.append('Affected SOP Class UID        : none')
-        s.append('Data Set                      : %s' %dataset)
-        s.append('DIMSE Status                  : 0x%04x' %ds.Status)
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('DIMSE Status                  : 0x{0:04x}'.format(ds.Status))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
@@ -686,10 +681,10 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== INCOMING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-ECHO RQ')
-        s.append('Presentation Context ID       : %s' %dimse_msg.ID)
-        s.append('Message ID                    : %s' %ds.MessageID)
-        s.append('Data Set                      : %s' %'none')
+        s.append('Message Type                  : {0!s}'.format('C-ECHO RQ'))
+        s.append('Presentation Context ID       : {0!s}'.format(dimse_msg.ID))
+        s.append('Message ID                    : {0!s}'.format(ds.MessageID))
+        s.append('Data Set                      : {0!s}'.format('none'))
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
 
@@ -729,14 +724,13 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== INCOMING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-STORE RQ')
-        s.append('Presentation Context ID       : %s' %dimse_msg.ID)
-        s.append('Message ID                    : %s' %ds.MessageID)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Affected SOP Instance UID     : %s'
-                 %ds.AffectedSOPInstanceUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('Priority                      : %s' %priority)
+        s.append('Message Type                  : {0!s}'.format('C-STORE RQ'))
+        s.append('Presentation Context ID       : {0!s}'.format(dimse_msg.ID))
+        s.append('Message ID                    : {0!s}'.format(ds.MessageID))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Affected SOP Instance UID     : {0!s}'.format(ds.AffectedSOPInstanceUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('Priority                      : {0!s}'.format(priority))
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
         for line in s:
@@ -756,7 +750,7 @@ class DIMSEServiceProvider(object):
             dataset = 'Present'
 
         # See PS3.4 Annex B.2.3 for Storage Service Class Statuses
-        status = '0x%04x' %ds.Status
+        status = '0x{0:04x}'.format(ds.Status)
         if status == '0x0000':
             status += ': Success'
         elif '0xb000' in status:
@@ -778,15 +772,13 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== INCOMING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-STORE RSP')
-        s.append('Presentation Context ID       : %s' %dimse_msg.ID)
-        s.append('Message ID Being Responded To : %s'
-                 %ds.MessageIDBeingRespondedTo)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Affected SOP Instance UID     : %s'
-                 %ds.AffectedSOPInstanceUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('DIMSE Status                  : %s' %status)
+        s.append('Message Type                  : {0!s}'.format('C-STORE RSP'))
+        s.append('Presentation Context ID       : {0!s}'.format(dimse_msg.ID))
+        s.append('Message ID Being Responded To : {0!s}'.format(ds.MessageIDBeingRespondedTo))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Affected SOP Instance UID     : {0!s}'.format(ds.AffectedSOPInstanceUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('DIMSE Status                  : {0!s}'.format(status))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
@@ -820,11 +812,11 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== INCOMING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-FIND RQ')
-        s.append('Message ID                    : %s' %ds.MessageID)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('Priority                      : %s' %priority)
+        s.append('Message Type                  : {0!s}'.format('C-FIND RQ'))
+        s.append('Message ID                    : {0!s}'.format(ds.MessageID))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('Priority                      : {0!s}'.format(priority))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
@@ -855,12 +847,11 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== INCOMING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-FIND RSP')
-        s.append('Message ID Being Responded To : %s'
-                 %ds.MessageIDBeingRespondedTo)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('DIMSE Status                  : 0x%04x' %ds.Status)
+        s.append('Message Type                  : {0!s}'.format('C-FIND RSP'))
+        s.append('Message ID Being Responded To : {0!s}'.format(ds.MessageIDBeingRespondedTo))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('DIMSE Status                  : 0x{0:04x}'.format(ds.Status))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
@@ -900,11 +891,11 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== INCOMING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-GET RQ')
-        s.append('Message ID                    : %s' %ds.MessageID)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('Priority                      : %s' %priority)
+        s.append('Message Type                  : {0!s}'.format('C-GET RQ'))
+        s.append('Message ID                    : {0!s}'.format(ds.MessageID))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('Priority                      : {0!s}'.format(priority))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
@@ -933,20 +924,16 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== INCOMING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-GET RSP')
-        s.append('Presentation Context ID       : %s' %dimse_msg.ID)
-        s.append('Message ID Being Responded To : %s'
-                 %ds.MessageIDBeingRespondedTo)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Remaining Sub-operations      : %s' %no_remain)
-        s.append('Completed Sub-operations      : %s'
-                 %ds.NumberOfCompletedSuboperations)
-        s.append('Failed Sub-operations         : %s'
-                 %ds.NumberOfFailedSuboperations)
-        s.append('Warning Sub-operations        : %s'
-                 %ds.NumberOfWarningSuboperations)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('DIMSE Status                  : 0x%04x' %ds.Status)
+        s.append('Message Type                  : {0!s}'.format('C-GET RSP'))
+        s.append('Presentation Context ID       : {0!s}'.format(dimse_msg.ID))
+        s.append('Message ID Being Responded To : {0!s}'.format(ds.MessageIDBeingRespondedTo))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Remaining Sub-operations      : {0!s}'.format(no_remain))
+        s.append('Completed Sub-operations      : {0!s}'.format(ds.NumberOfCompletedSuboperations))
+        s.append('Failed Sub-operations         : {0!s}'.format(ds.NumberOfFailedSuboperations))
+        s.append('Warning Sub-operations        : {0!s}'.format(ds.NumberOfWarningSuboperations))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('DIMSE Status                  : 0x{0:04x}'.format(ds.Status))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')
@@ -984,19 +971,15 @@ class DIMSEServiceProvider(object):
         s = []
         s.append('===================== INCOMING DIMSE MESSAGE ================'
                  '====')
-        s.append('Message Type                  : %s' %'C-MOVE RSP')
-        s.append('Message ID Being Responded To : %s'
-                 %ds.MessageIDBeingRespondedTo)
-        s.append('Affected SOP Class UID        : %s' %ds.AffectedSOPClassUID)
-        s.append('Remaining Sub-operations      : %s' %no_remain)
-        s.append('Completed Sub-operations      : %s'
-                 %ds.NumberOfCompletedSuboperations)
-        s.append('Failed Sub-operations         : %s'
-                 %ds.NumberOfFailedSuboperations)
-        s.append('Warning Sub-operations        : %s'
-                 %ds.NumberOfWarningSuboperations)
-        s.append('Data Set                      : %s' %dataset)
-        s.append('DIMSE Status                  : 0x%04x' %ds.Status)
+        s.append('Message Type                  : {0!s}'.format('C-MOVE RSP'))
+        s.append('Message ID Being Responded To : {0!s}'.format(ds.MessageIDBeingRespondedTo))
+        s.append('Affected SOP Class UID        : {0!s}'.format(ds.AffectedSOPClassUID))
+        s.append('Remaining Sub-operations      : {0!s}'.format(no_remain))
+        s.append('Completed Sub-operations      : {0!s}'.format(ds.NumberOfCompletedSuboperations))
+        s.append('Failed Sub-operations         : {0!s}'.format(ds.NumberOfFailedSuboperations))
+        s.append('Warning Sub-operations        : {0!s}'.format(ds.NumberOfWarningSuboperations))
+        s.append('Data Set                      : {0!s}'.format(dataset))
+        s.append('DIMSE Status                  : 0x{0:04x}'.format(ds.Status))
 
         s.append('======================= END DIMSE MESSAGE ==================='
                  '====')

--- a/pynetdicom3/PDU.py
+++ b/pynetdicom3/PDU.py
@@ -94,7 +94,7 @@ class PDU(object):
                     self.parameters[ii] = \
                         bytes(self.parameters[ii].title(), 'utf-8')
 
-                self.formats[ii] = '%ds' %len(self.parameters[ii])
+                self.formats[ii] = '{0:d}s'.format(len(self.parameters[ii]))
                 # Make sure the parameter is a bytes
 
 
@@ -608,34 +608,34 @@ class A_ASSOCIATE_RQ_PDU(PDU):
     def __str__(self):
         s = 'A-ASSOCIATE-RQ PDU\n'
         s += '==================\n'
-        s += '  PDU type: 0x%02x\n' %self.pdu_type
-        s += '  PDU length: %d bytes\n' %self.length
-        s += '  Protocol version: %d\n' %self.protocol_version
-        s += '  Called AET:  %s\n' %self.called_ae_title
-        s += '  Calling AET: %s\n' %self.calling_ae_title
+        s += '  PDU type: 0x{0:02x}\n'.format(self.pdu_type)
+        s += '  PDU length: {0:d} bytes\n'.format(self.length)
+        s += '  Protocol version: {0:d}\n'.format(self.protocol_version)
+        s += '  Called AET:  {0!s}\n'.format(self.called_ae_title)
+        s += '  Calling AET: {0!s}\n'.format(self.calling_ae_title)
         s += '\n'
 
         s += '  Variable Items:\n'
         s += '  ---------------\n'
         s += '  * Application Context Item\n'
-        s += '    - Context name: =%s\n' %self.application_context_name
+        s += '    - Context name: ={0!s}\n'.format(self.application_context_name)
 
         s += '  * Presentation Context Item(s):\n'
 
         for ii in self.presentation_context:
-            item_str = '%s' %ii
+            item_str = '{0!s}'.format(ii)
             item_str_list = item_str.split('\n')
-            s += '    - %s\n' %item_str_list[0]
+            s += '    - {0!s}\n'.format(item_str_list[0])
             for jj in item_str_list[1:-1]:
-                s += '      %s\n' %jj
+                s += '      {0!s}\n'.format(jj)
 
         s += '  * User Information Item(s):\n'
         for ii in self.user_information.user_data:
-            item_str = '%s' %ii
+            item_str = '{0!s}'.format(ii)
             item_str_list = item_str.split('\n')
-            s += '    - %s\n' %item_str_list[0]
+            s += '    - {0!s}\n'.format(item_str_list[0])
             for jj in item_str_list[1:-1]:
-                s += '      %s\n' %jj
+                s += '      {0!s}\n'.format(jj)
 
         return s
 
@@ -1004,34 +1004,34 @@ class A_ASSOCIATE_AC_PDU(PDU):
     def __str__(self):
         s = 'A-ASSOCIATE-AC PDU\n'
         s += '==================\n'
-        s += '  PDU type: 0x%02x\n' %self.pdu_type
-        s += '  PDU length: %d bytes\n' %self.length
-        s += '  Protocol version: %d\n' %self.protocol_version
-        s += '  Reserved (Called AET):  %s\n' %self.reserved_aet
-        s += '  Reserved (Calling AET): %s\n' %self.reserved_aec
+        s += '  PDU type: 0x{0:02x}\n'.format(self.pdu_type)
+        s += '  PDU length: {0:d} bytes\n'.format(self.length)
+        s += '  Protocol version: {0:d}\n'.format(self.protocol_version)
+        s += '  Reserved (Called AET):  {0!s}\n'.format(self.reserved_aet)
+        s += '  Reserved (Calling AET): {0!s}\n'.format(self.reserved_aec)
         s += '\n'
 
         s += '  Variable Items:\n'
         s += '  ---------------\n'
         s += '  * Application Context Item\n'
-        s += '    -  Context name: =%s\n' %self.application_context_name
+        s += '    -  Context name: ={0!s}\n'.format(self.application_context_name)
 
         s += '  * Presentation Context Item(s):\n'
 
         for ii in self.presentation_context:
-            item_str = '%s' %ii
+            item_str = '{0!s}'.format(ii)
             item_str_list = item_str.split('\n')
-            s += '    -  %s\n' %item_str_list[0]
+            s += '    -  {0!s}\n'.format(item_str_list[0])
             for jj in item_str_list[1:-1]:
-                s += '       %s\n' %jj
+                s += '       {0!s}\n'.format(jj)
 
         s += '  * User Information Item(s):\n'
         for ii in self.user_information.user_data:
-            item_str = '%s' %ii
+            item_str = '{0!s}'.format(ii)
             item_str_list = item_str.split('\n')
-            s += '    -  %s\n' %item_str_list[0]
+            s += '    -  {0!s}\n'.format(item_str_list[0])
             for jj in item_str_list[1:-1]:
-                s += '       %s\n' %jj
+                s += '       {0!s}\n'.format(jj)
 
         return s
 
@@ -1289,11 +1289,11 @@ class A_ASSOCIATE_RJ_PDU(PDU):
     def __str__(self):
         s = 'A-ASSOCIATE-RJ PDU\n'
         s += '==================\n'
-        s += '  PDU type: 0x%02x\n' %self.pdu_type
-        s += '  PDU length: %d bytes\n' %self.length
-        s += '  Result: %s\n' %self.result_str
-        s += '  Source: %s\n' %self.source_str
-        s += '  Reason/Diagnostic: %s\n' %self.reason_str
+        s += '  PDU type: 0x{0:02x}\n'.format(self.pdu_type)
+        s += '  PDU length: {0:d} bytes\n'.format(self.length)
+        s += '  Result: {0!s}\n'.format(self.result_str)
+        s += '  Source: {0!s}\n'.format(self.source_str)
+        s += '  Reason/Diagnostic: {0!s}\n'.format(self.reason_str)
 
         return s
 
@@ -1449,18 +1449,18 @@ class P_DATA_TF_PDU(PDU):
     def __str__(self):
         s = 'P-DATA-TF PDU\n'
         s += '=============\n'
-        s += '  PDU type: 0x%02x\n' %self.pdu_type
-        s += '  PDU length: %d bytes\n' %self.length
+        s += '  PDU type: 0x{0:02x}\n'.format(self.pdu_type)
+        s += '  PDU length: {0:d} bytes\n'.format(self.length)
         s += '\n'
         s += '  Presentation Data Value Item(s):\n'
         s += '  --------------------------------\n'
 
         for ii in self.presentation_data_value_items:
-            item_str = '%s' %ii
+            item_str = '{0!s}'.format(ii)
             item_str_list = item_str.split('\n')
-            s += '  *  %s\n' %item_str_list[0]
+            s += '  *  {0!s}\n'.format(item_str_list[0])
             for jj in item_str_list[1:-1]:
-                s += '     %s\n' %jj
+                s += '     {0!s}\n'.format(jj)
 
         return s
 
@@ -1572,8 +1572,8 @@ class A_RELEASE_RQ_PDU(PDU):
     def __str__(self):
         s = 'A-RELEASE-RQ PDU\n'
         s += '================\n'
-        s += '  PDU type: 0x%02x\n' %self.pdu_type
-        s += '  PDU length: %d bytes\n' %self.length
+        s += '  PDU type: 0x{0:02x}\n'.format(self.pdu_type)
+        s += '  PDU length: {0:d} bytes\n'.format(self.length)
 
         return s
 
@@ -1686,8 +1686,8 @@ class A_RELEASE_RP_PDU(PDU):
     def __str__(self):
         s = 'A-RELEASE-RP PDU\n'
         s += '================\n'
-        s += '  PDU type: 0x%02x\n' %self.pdu_type
-        s += '  PDU length: %d bytes\n' %self.length
+        s += '  PDU type: 0x{0:02x}\n'.format(self.pdu_type)
+        s += '  PDU length: {0:d} bytes\n'.format(self.length)
 
         return s
 
@@ -1844,10 +1844,10 @@ class A_ABORT_PDU(PDU):
     def __str__(self):
         s = "A-ABORT PDU\n"
         s += "===========\n"
-        s += "  PDU type: 0x%02x\n" % self.pdu_type
-        s += "  PDU length: %d bytes\n" % self.pdu_length
-        s += "  Abort Source: %s\n" % self.source_str
-        s += "  Reason/Diagnostic: %s\n" % self.reason_str
+        s += "  PDU type: 0x{0:02x}\n".format(self.pdu_type)
+        s += "  PDU length: {0:d} bytes\n".format(self.pdu_length)
+        s += "  Abort Source: {0!s}\n".format(self.source_str)
+        s += "  Reason/Diagnostic: {0!s}\n".format(self.reason_str)
 
         return s
 
@@ -2001,7 +2001,7 @@ class ApplicationContextItem(PDU):
         return 4 + self.item_length
 
     def __str__(self):
-        s = '%s (%s)\n' %(self.application_context_name,
+        s = '{0!s} ({1!s})\n'.format(self.application_context_name,
                           self.application_context_name.title())
         return s
 
@@ -2230,16 +2230,16 @@ class PresentationContextItemRQ(PDU):
 
     def __str__(self):
         s = "Presentation Context (RQ) Item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.length
-        s += "  Context ID: %d\n" % self.ID
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.length)
+        s += "  Context ID: {0:d}\n".format(self.ID)
 
         for ii in self.abstract_transfer_syntax_sub_items:
-            item_str = '%s' %ii
+            item_str = '{0!s}'.format(ii)
             item_str_list = item_str.split('\n')
-            s += '  + %s\n' %item_str_list[0]
+            s += '  + {0!s}\n'.format(item_str_list[0])
             for jj in item_str_list[1:-1]:
-                s += '    %s\n' %jj
+                s += '    {0!s}\n'.format(jj)
 
         return s
 
@@ -2439,16 +2439,16 @@ class PresentationContextItemAC(PDU):
 
     def __str__(self):
         s = "Presentation Context (AC) Item\n"
-        s += "  Item type:   0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  Context ID: %d\n" % self.presentation_context_id
-        s += "  Result/Reason: %s\n" % self.result_str
+        s += "  Item type:   0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  Context ID: {0:d}\n".format(self.presentation_context_id)
+        s += "  Result/Reason: {0!s}\n".format(self.result_str)
 
-        item_str = '%s' %self.transfer_syntax_sub_item
+        item_str = '{0!s}'.format(self.transfer_syntax_sub_item)
         item_str_list = item_str.split('\n')
-        s += '  +  %s\n' %item_str_list[0]
+        s += '  +  {0!s}\n'.format(item_str_list[0])
         for jj in item_str_list[1:-1]:
-            s += '     %s\n' %jj
+            s += '     {0!s}\n'.format(jj)
 
         return s
 
@@ -2590,9 +2590,9 @@ class AbstractSyntaxSubItem(PDU):
 
     def __str__(self):
         s = "Abstract Syntax Sub-item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += '  Syntax name: =%s\n' % self.abstract_syntax
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += '  Syntax name: ={0!s}\n'.format(self.abstract_syntax)
 
         return s
 
@@ -2746,9 +2746,9 @@ class TransferSyntaxSubItem(PDU):
 
     def __str__(self):
         s = "Transfer syntax sub item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += '  Transfer syntax name: =%s\n' % self.transfer_syntax_name
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += '  Transfer syntax name: ={0!s}\n'.format(self.transfer_syntax_name)
 
         return s
 
@@ -2901,10 +2901,10 @@ class PresentationDataValueItem(PDU):
 
     def __str__(self):
         s = "Presentation Value Data Item\n"
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  Context ID: %d\n" % self.presentation_context_id
-        s += "  Data value: 0x%s ...\n" %' 0x'.join(
-            format(x, '02x') for x in self.presentation_data_value[:10])
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  Context ID: {0:d}\n".format(self.presentation_context_id)
+        s += "  Data value: 0x{0!s} ...\n".format(' 0x'.join(
+            format(x, '02x') for x in self.presentation_data_value[:10]))
 
         return s
 
@@ -3081,12 +3081,12 @@ class UserInformationItem(PDU):
 
     def __str__(self):
         s = " User information item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d\n" % self.item_length
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d}\n".format(self.item_length)
         s += "  User Data:\n "
 
         for ii in self.user_data[1:]:
-            s += "  %s" %ii
+            s += "  {0!s}".format(ii)
 
         return s
 
@@ -3305,9 +3305,9 @@ class MaximumLengthSubItem(PDU):
 
     def __str__(self):
         s = "Maximum length Sub-item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  Maximum length received: %d\n" % self.maximum_length_received
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  Maximum length received: {0:d}\n".format(self.maximum_length_received)
         return s
 
 class ImplementationClassUIDSubItem(PDU):
@@ -3417,9 +3417,9 @@ class ImplementationClassUIDSubItem(PDU):
 
     def __str__(self):
         s = "Implementation Class UID Sub-item\n"
-        s += "  Item type: 0x%02x\n" %self.item_type
-        s += "  Item length: %d bytes\n" %self.item_length
-        s += "  Implementation class UID: '%s'\n" %self.implementation_class_uid
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  Implementation class UID: '{0!s}'\n".format(self.implementation_class_uid)
 
         return s
 
@@ -3560,10 +3560,10 @@ class ImplementationVersionNameSubItem(PDU):
 
     def __str__(self):
         s = "Implementation Version Name Sub-item\n"
-        s += "  Item type: 0x%02x\n" %self.item_type
-        s += "  Item length: %d bytes\n" %self.item_length
-        s += "  Implementation version name: %s\n" % \
-            self.implementation_version_name
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  Implementation version name: {0!s}\n".format( \
+            self.implementation_version_name)
 
         return s
 
@@ -3725,12 +3725,12 @@ class SCP_SCU_RoleSelectionSubItem(PDU):
 
     def __str__(self):
         s = "SCP/SCU Role Selection Sub-item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  UID length: %d bytes\n" % self.uid_length
-        s += "  SOP Class UID: %s\n" % self.UID
-        s += "  SCU Role: %d\n" % self.SCU
-        s += "  SCP Role: %d\n" % self.SCP
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  UID length: {0:d} bytes\n".format(self.uid_length)
+        s += "  SOP Class UID: {0!s}\n".format(self.UID)
+        s += "  SCU Role: {0:d}\n".format(self.SCU)
+        s += "  SCP Role: {0:d}\n".format(self.SCP)
 
         return s
 
@@ -3946,12 +3946,12 @@ class AsynchronousOperationsWindowSubItem(PDU):
 
     def __str__(self):
         s = "Asynchronous Operation Window Sub-item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  Max. number of operations invoked: %d\n" % \
-            self.maximum_number_operations_invoked
-        s += "  Max. number of operations performed: %d\n" % \
-            self.maximum_number_operations_performed
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  Max. number of operations invoked: {0:d}\n".format( \
+            self.maximum_number_operations_invoked)
+        s += "  Max. number of operations performed: {0:d}\n".format( \
+            self.maximum_number_operations_performed)
 
         return s
 
@@ -4003,18 +4003,18 @@ class UserIdentitySubItemRQ(PDU):
 
     def __str__(self):
         s = "User Identity (RQ) Sub-item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  User identity type: %d\n" % self.user_identity_type
-        s += "  Positive response requested: %d\n" % \
-            self.positive_response_requested
-        s += "  Primary field length: %d bytes\n" % self.primary_field_length
-        s += "  Primary field: %s\n" % self.primary_field
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  User identity type: {0:d}\n".format(self.user_identity_type)
+        s += "  Positive response requested: {0:d}\n".format( \
+            self.positive_response_requested)
+        s += "  Primary field length: {0:d} bytes\n".format(self.primary_field_length)
+        s += "  Primary field: {0!s}\n".format(self.primary_field)
 
         if self.user_identity_type == 0x02:
-            s += "  Secondary field length: %d bytes\n" % \
-                self.secondary_field_length
-            s += "  Secondary field: %s\n" % self.secondary_field
+            s += "  Secondary field length: {0:d} bytes\n".format( \
+                self.secondary_field_length)
+            s += "  Secondary field: {0!s}\n".format(self.secondary_field)
         else:
             s += "  Secondary field length: (not used)\n"
             s += "  Secondary field: (not used)\n"
@@ -4216,11 +4216,11 @@ class UserIdentitySubItemAC(PDU):
 
     def __str__(self):
         s = "User Identity (AC) Sub-item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  Server response length: %d bytes\n" % \
-            self.server_response_length
-        s += "  Server response: %s\n" % self.server_response
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  Server response length: {0:d} bytes\n".format( \
+            self.server_response_length)
+        s += "  Server response: {0!s}\n".format(self.server_response)
 
         return s
 
@@ -4457,12 +4457,12 @@ class SOPClassExtendedNegotiationSubItem(PDU):
 
     def __str__(self):
         s = "SOP Class Extended Negotiation Sub-item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  SOP class UID length: %d bytes\n" % self.sop_class_uid_length
-        s += "  SOP class: =%s\n" % self.sop_class_uid
-        s += "  Service class application information: %s\n" % \
-            self.service_class_application_information
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  SOP class UID length: {0:d} bytes\n".format(self.sop_class_uid_length)
+        s += "  SOP class: ={0!s}\n".format(self.sop_class_uid)
+        s += "  Service class application information: {0!s}\n".format( \
+            self.service_class_application_information)
 
         return s
 
@@ -4680,19 +4680,19 @@ class SOPClassCommonExtendedNegotiationSubItem(PDU):
 
     def __str__(self):
         s = "SOP Class Common Extended Negotiation Sub-item\n"
-        s += "  Item type: 0x%02x\n" % self.item_type
-        s += "  Item length: %d bytes\n" % self.item_length
-        s += "  SOP class UID length: %d bytes\n" % self.sop_class_uid_length
-        s += "  SOP class: =%s\n" % self.sop_class_uid
-        s += "  Service class UID length: %d bytes\n" % \
-            self.service_class_uid_length
-        s += "  Service class UID: =%s\n" % self.service_class_uid
-        s += "  Related general SOP class ID length: %d bytes\n" % \
-            self.related_general_sop_class_identification_length
+        s += "  Item type: 0x{0:02x}\n".format(self.item_type)
+        s += "  Item length: {0:d} bytes\n".format(self.item_length)
+        s += "  SOP class UID length: {0:d} bytes\n".format(self.sop_class_uid_length)
+        s += "  SOP class: ={0!s}\n".format(self.sop_class_uid)
+        s += "  Service class UID length: {0:d} bytes\n".format( \
+            self.service_class_uid_length)
+        s += "  Service class UID: ={0!s}\n".format(self.service_class_uid)
+        s += "  Related general SOP class ID length: {0:d} bytes\n".format( \
+            self.related_general_sop_class_identification_length)
         s += "  Related general SOP class ID(s):\n"
 
         for ii in self.related_general_sop_class_identification:
-            s += "    =%s (%s)\n" %(ii, ii.title())
+            s += "    ={0!s} ({1!s})\n".format(ii, ii.title())
 
         return s
 

--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -439,51 +439,49 @@ class ApplicationEntity(object):
     def __str__(self):
         """ Prints out the attribute values and status for the AE """
         str_out = "\n"
-        str_out += "Application Entity '%s' on %s:%s\n" %(self.ae_title,
+        str_out += "Application Entity '{0!s}' on {1!s}:{2!s}\n".format(self.ae_title,
                                                           self.address,
                                                           self.port)
 
         str_out += "\n"
         str_out += "  Available Transfer Syntax(es):\n"
         for syntax in self.transfer_syntaxes:
-            str_out += "\t%s\n" %syntax
+            str_out += "\t{0!s}\n".format(syntax)
 
         str_out += "\n"
         str_out += "  Supported SOP Classes (SCU):\n"
         if len(self.scu_supported_sop) == 0:
             str_out += "\tNone\n"
         for sop_class in self.scu_supported_sop:
-            str_out += "\t%s\n" %sop_class
+            str_out += "\t{0!s}\n".format(sop_class)
 
         str_out += "\n"
         str_out += "  Supported SOP Classes (SCP):\n"
         if len(self.scp_supported_sop) == 0:
             str_out += "\tNone\n"
         for sop_class in self.scp_supported_sop:
-            str_out += "\t%s\n" %sop_class
+            str_out += "\t{0!s}\n".format(sop_class)
 
         str_out += "\n"
-        str_out += "  ACSE timeout: %s s\n" %self.acse_timeout
-        str_out += "  DIMSE timeout: %s s\n" %self.dimse_timeout
-        str_out += "  Network timeout: %s s\n" %self.network_timeout
+        str_out += "  ACSE timeout: {0!s} s\n".format(self.acse_timeout)
+        str_out += "  DIMSE timeout: {0!s} s\n".format(self.dimse_timeout)
+        str_out += "  Network timeout: {0!s} s\n".format(self.network_timeout)
 
         if self.require_called_aet != '' or self.require_calling_aet != '':
             str_out += "\n"
         if self.require_calling_aet != '':
-            str_out += "  Required calling AE title: %s\n" \
-                                        % self.require_calling_aet
+            str_out += "  Required calling AE title: {0!s}\n".format(self.require_calling_aet)
         if self.require_called_aet != '':
-            str_out += "  Required called AE title: %s\n" \
-                                        % self.require_called_aet
+            str_out += "  Required called AE title: {0!s}\n".format(self.require_called_aet)
 
         str_out += "\n"
 
         # Association information
-        str_out += '  Association(s): %s/%s\n' %(len(self.active_associations),
+        str_out += '  Association(s): {0!s}/{1!s}\n'.format(len(self.active_associations),
                                                  self.maximum_associations)
 
         for assoc in self.active_associations:
-            str_out += '\tPeer: %s on %s:%s\n' %(assoc.peer_ae['AET'],
+            str_out += '\tPeer: {0!s} on {1!s}:{2!s}\n'.format(assoc.peer_ae['AET'],
                                                  assoc.peer_ae['Address'],
                                                  assoc.peer_ae['Port'])
 

--- a/pynetdicom3/apps/echoscp/echoscp.py
+++ b/pynetdicom3/apps/echoscp/echoscp.py
@@ -160,7 +160,7 @@ if args.log_level:
 if args.log_config:
     fileConfig(args.log_config)
 
-logger.debug('$echoscp.py v%s %s $' %('0.2.1', '2016-04-12'))
+logger.debug('$echoscp.py v{0!s} {1!s} $'.format('0.2.1', '2016-04-12'))
 logger.debug('')
 
 # Validate port

--- a/pynetdicom3/apps/findscp/findscp.py
+++ b/pynetdicom3/apps/findscp/findscp.py
@@ -120,7 +120,7 @@ if args.debug:
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
 
-logger.debug('$findscp.py v%s %s $' %('0.1.0', '2016-04-11'))
+logger.debug('$findscp.py v{0!s} {1!s} $'.format('0.1.0', '2016-04-11'))
 logger.debug('')
 
 # Validate port
@@ -130,8 +130,7 @@ if isinstance(args.port, int):
     try:
         test_socket.bind((os.popen('hostname').read()[:-1], args.port))
     except socket.error:
-        logger.error("Cannot listen on port %d, insufficient priveleges"
-            %args.port)
+        logger.error("Cannot listen on port {0:d}, insufficient priveleges".format(args.port))
         sys.exit()
 
 # Set Transfer Syntax options

--- a/pynetdicom3/apps/findscu/findscu.py
+++ b/pynetdicom3/apps/findscu/findscu.py
@@ -119,7 +119,7 @@ if args.debug:
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
 
-logger.debug('$findscu.py v%s %s $' %('0.1.0', '2016-02-15'))
+logger.debug('$findscu.py v{0!s} {1!s} $'.format('0.1.0', '2016-02-15'))
 logger.debug('')
 
 # Create application entity
@@ -142,10 +142,10 @@ if assoc.is_established:
         dataset = read_file(f, force=True)
         f.close()
     except IOError:
-        logger.error('Cannot read input file %s' %args.dcmfile_in)
+        logger.error('Cannot read input file {0!s}'.format(args.dcmfile_in))
         sys.exit()
     except:
-        logger.error('File may not be DICOM %s' %args.dcmfile_in)
+        logger.error('File may not be DICOM {0!s}'.format(args.dcmfile_in))
         sys.exit()
 
     # Modify keys if requested

--- a/pynetdicom3/apps/getscp/getscp.py
+++ b/pynetdicom3/apps/getscp/getscp.py
@@ -120,7 +120,7 @@ if args.debug:
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
 
-logger.debug('$getscp.py v%s %s $' %('0.1.0', '2016-04-11'))
+logger.debug('$getscp.py v{0!s} {1!s} $'.format('0.1.0', '2016-04-11'))
 logger.debug('')
 
 # Validate port
@@ -130,8 +130,7 @@ if isinstance(args.port, int):
     try:
         test_socket.bind((os.popen('hostname').read()[:-1], args.port))
     except socket.error:
-        logger.error("Cannot listen on port %d, insufficient priveleges"
-            %args.port)
+        logger.error("Cannot listen on port {0:d}, insufficient priveleges".format(args.port))
         sys.exit()
 
 # Set Transfer Syntax options

--- a/pynetdicom3/apps/getscu/getscu.py
+++ b/pynetdicom3/apps/getscu/getscu.py
@@ -116,7 +116,7 @@ if args.debug:
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
 
-logger.debug('$getscu.py v%s %s $' %('0.1.0', '2016-02-15'))
+logger.debug('$getscu.py v{0!s} {1!s} $'.format('0.1.0', '2016-02-15'))
 logger.debug('')
 
 
@@ -201,8 +201,8 @@ def on_c_store(dataset):
     except:
         pass
 
-    filename = '%s.%s' %(mode_prefix, dataset.SOPInstanceUID)
-    logger.info('Storing DICOM file: %s' %filename)
+    filename = '{0!s}.{1!s}'.format(mode_prefix, dataset.SOPInstanceUID)
+    logger.info('Storing DICOM file: {0!s}'.format(filename))
 
     if os.path.exists(filename):
         logger.warning('DICOM file already exists, overwriting')

--- a/pynetdicom3/apps/movescp/movescp.py
+++ b/pynetdicom3/apps/movescp/movescp.py
@@ -120,7 +120,7 @@ if args.debug:
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
 
-logger.debug('$movescp.py v%s %s $' %('0.1.0', '2016-04-12'))
+logger.debug('$movescp.py v{0!s} {1!s} $'.format('0.1.0', '2016-04-12'))
 logger.debug('')
 
 # Validate port
@@ -130,8 +130,7 @@ if isinstance(args.port, int):
     try:
         test_socket.bind((os.popen('hostname').read()[:-1], args.port))
     except socket.error:
-        logger.error("Cannot listen on port %d, insufficient priveleges"
-            %args.port)
+        logger.error("Cannot listen on port {0:d}, insufficient priveleges".format(args.port))
         sys.exit()
 
 # Set Transfer Syntax options

--- a/pynetdicom3/apps/movescu/movescu.py
+++ b/pynetdicom3/apps/movescu/movescu.py
@@ -124,7 +124,7 @@ if args.debug:
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
 
-logger.debug('$movescu.py v%s %s $' %('0.1.0', '2016-03-15'))
+logger.debug('$movescu.py v{0!s} {1!s} $'.format('0.1.0', '2016-03-15'))
 logger.debug('')
 
 # Create application entity
@@ -181,8 +181,8 @@ def on_c_store(sop_class, dataset):
         A valid return status, see the StorageServiceClass for the
         available statuses
     """
-    filename = 'CT.%s' %dataset.SOPInstanceUID
-    logger.info('Storing DICOM file: %s' %filename)
+    filename = 'CT.{0!s}'.format(dataset.SOPInstanceUID)
+    logger.info('Storing DICOM file: {0!s}'.format(filename))
 
     if os.path.exists(filename):
         logger.warning('DICOM file already exists, overwriting')

--- a/pynetdicom3/apps/storescp/storescp.py
+++ b/pynetdicom3/apps/storescp/storescp.py
@@ -159,7 +159,7 @@ if args.debug:
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
 
-LOGGER.debug('$storescp.py v%s %s $' %('0.2.0', '2016-03-23'))
+LOGGER.debug('$storescp.py v{0!s} {1!s} $'.format('0.2.0', '2016-03-23'))
 LOGGER.debug('')
 
 # Validate port
@@ -169,8 +169,7 @@ if isinstance(args.port, int):
     try:
         test_socket.bind((os.popen('hostname').read()[:-1], args.port))
     except socket.error:
-        LOGGER.error("Cannot listen on port %d, insufficient priveleges"
-            %args.port)
+        LOGGER.error("Cannot listen on port {0:d}, insufficient priveleges".format(args.port))
         sys.exit()
 
 # Set Transfer Syntax options
@@ -231,8 +230,8 @@ def on_c_store(dataset):
     except:
         pass
 
-    filename = '%s.%s' %(mode_prefix, dataset.SOPInstanceUID)
-    LOGGER.info('Storing DICOM file: %s' %filename)
+    filename = '{0!s}.{1!s}'.format(mode_prefix, dataset.SOPInstanceUID)
+    LOGGER.info('Storing DICOM file: {0!s}'.format(filename))
 
     if os.path.exists(filename):
         LOGGER.warning('DICOM file already exists, overwriting')
@@ -257,13 +256,13 @@ def on_c_store(dataset):
             ds.save_as(filename)
         except IOError:
             LOGGER.error('Could not write file to specified directory:')
-            LOGGER.error("    %s" %os.path.dirname(filename))
+            LOGGER.error("    {0!s}".format(os.path.dirname(filename)))
             LOGGER.error('Directory may not exist or you may not have write '
                     'permission')
             return 0xA700 # Failed - Out of Resources
         except:
             LOGGER.error('Could not write file to specified directory:')
-            LOGGER.error("    %s" %os.path.dirname(filename))
+            LOGGER.error("    {0!s}".format(os.path.dirname(filename)))
             return 0xA700 # Failed - Out of Resources
 
     return 0x0000 # Success
@@ -272,7 +271,7 @@ def on_c_store(dataset):
 if args.output_directory is not None:
     if not os.access(args.output_directory, os.W_OK|os.X_OK):
         LOGGER.error("No write permissions or the output directory may not exist:")
-        LOGGER.error("    %s" %args.output_directory)
+        LOGGER.error("    {0!s}".format(args.output_directory))
         sys.exit()
 
 scp_classes = [x for x in StorageSOPClassList]

--- a/pynetdicom3/apps/storescu/storescu.py
+++ b/pynetdicom3/apps/storescu/storescu.py
@@ -110,7 +110,7 @@ if args.debug:
     pynetdicom_logger = logging.getLogger('pynetdicom3')
     pynetdicom_logger.setLevel(logging.DEBUG)
 
-logger.debug('$storescu.py v%s %s $' %('0.1.0', '2016-02-10'))
+logger.debug('$storescu.py v{0!s} {1!s} $'.format('0.1.0', '2016-02-10'))
 logger.debug('')
 
 # Check file exists and is readable and DICOM
@@ -120,10 +120,10 @@ try:
     dataset = read_file(f, force=True)
     f.close()
 except IOError:
-    logger.error('Cannot read input file %s' %args.dcmfile_in)
+    logger.error('Cannot read input file {0!s}'.format(args.dcmfile_in))
     sys.exit()
 except:
-    logger.error('File may not be DICOM %s' %args.dcmfile_in)
+    logger.error('File may not be DICOM {0!s}'.format(args.dcmfile_in))
     sys.exit()
 
 # Set Transfer Syntax options
@@ -150,7 +150,7 @@ ae = AE(ae_title=args.calling_aet,
 assoc = ae.associate(args.peer, args.port, args.called_aet)
 
 if assoc.is_established:
-    logger.info('Sending file: %s' %args.dcmfile_in)
+    logger.info('Sending file: {0!s}'.format(args.dcmfile_in))
 
     status = assoc.send_c_store(dataset)
 

--- a/pynetdicom3/primitives.py
+++ b/pynetdicom3/primitives.py
@@ -922,8 +922,8 @@ class P_DATA(object):
         """String representation of the class."""
         s = 'P-DATA\n'
         for pdv in self.presentation_data_value_list:
-            s += '  Context ID: %s\n' %pdv[0]
-            s += '  Value Length: %s bytes\n' %len(pdv[1])
+            s += '  Context ID: {0!s}\n'.format(pdv[0])
+            s += '  Value Length: {0!s} bytes\n'.format(len(pdv[1]))
             header_byte = pdv[1][0]
             s += "  Message Control Header Byte: {:08b}\n".format(header_byte)
 
@@ -1025,8 +1025,8 @@ class MaximumLengthNegotiation(ServiceParameter):
     def __str__(self):
         """String representation of the class."""
         s = "Maximum Length Negotiation\n"
-        s += "  Maximum length received: %d bytes\n" % \
-            self.maximum_length_received
+        s += "  Maximum length received: {0:d} bytes\n".format( \
+            self.maximum_length_received)
         return s
 
 
@@ -1126,7 +1126,7 @@ class ImplementationClassUIDNotification(ServiceParameter):
     def __str__(self):
         """String representation of the class."""
         s = "Implementation Class UID\n"
-        s += "  Implementation class UID: %s\n" % self.implementation_class_uid
+        s += "  Implementation class UID: {0!s}\n".format(self.implementation_class_uid)
         return s
 
 
@@ -1220,8 +1220,8 @@ class ImplementationVersionNameNotification(ServiceParameter):
     def __str__(self):
         """String representation of the class."""
         s = "Implementation Version Name\n"
-        s += "  Implementation version name: %s\n" % \
-                self.implementation_version_name
+        s += "  Implementation version name: {0!s}\n".format( \
+                self.implementation_version_name)
         return s
 
 
@@ -1333,10 +1333,10 @@ class AsynchronousOperationsWindowNegotiation(ServiceParameter):
     def __str__(self):
         """String representation of the class."""
         s = "Asynchronous Operations Window\n"
-        s += "  Maximum number operations invoked: %d\n" % \
-                self.maximum_number_operations_invoked
-        s += "  Maximum number operations performed: %d\n" % \
-                self.maximum_number_operations_performed
+        s += "  Maximum number operations invoked: {0:d}\n".format( \
+                self.maximum_number_operations_invoked)
+        s += "  Maximum number operations performed: {0:d}\n".format( \
+                self.maximum_number_operations_performed)
         return s
 
 
@@ -2122,13 +2122,12 @@ class UserIdentityNegotiation(ServiceParameter):
         """String representation of the class."""
         s = 'User Identity Parameters\n'
         if self.server_response is None:
-            s += '  User identity type: %d\n' %self.user_identity_type
-            s += '  Positive response requested: %r\n' \
-                %self.positive_response_requested
-            s += '  Primary field: %s\n' %self.primary_field
+            s += '  User identity type: {0:d}\n'.format(self.user_identity_type)
+            s += '  Positive response requested: {0!r}\n'.format(self.positive_response_requested)
+            s += '  Primary field: {0!s}\n'.format(self.primary_field)
             if self.secondary_field is not None:
-                s += '  Secondary field: %s\n' %self.secondary_field
+                s += '  Secondary field: {0!s}\n'.format(self.secondary_field)
         else:
-            s += '  Server response: %s\n' %self.server_response
+            s += '  Server response: {0!s}\n'.format(self.server_response)
 
         return s

--- a/pynetdicom3/utils.py
+++ b/pynetdicom3/utils.py
@@ -179,7 +179,7 @@ def wrap_list(lst, prefix='  ', delimiter='  ', items_per_line=16,
             lines.append(line)
 
     if cutoff_output:
-        lines.insert(0, prefix + 'Only dumping %s bytes.' %max_size)
+        lines.insert(0, prefix + 'Only dumping {0!s} bytes.'.format(max_size))
 
     return lines
 
@@ -271,19 +271,19 @@ class PresentationContext(object):
 
     def __str__(self):
         """String representation of the Presentation Context."""
-        s = 'ID: %s\n' %self.ID
+        s = 'ID: {0!s}\n'.format(self.ID)
 
         if self.AbstractSyntax is not None:
-            s += 'Abstract Syntax: %s\n' %self.AbstractSyntax
+            s += 'Abstract Syntax: {0!s}\n'.format(self.AbstractSyntax)
 
         s += 'Transfer Syntax(es):\n'
         for syntax in self.TransferSyntax:
-            s += '\t=%s\n' %syntax
+            s += '\t={0!s}\n'.format(syntax)
 
         #s += 'SCP/SCU: %s/%s'
 
         if self.Result is not None:
-            s += 'Result: %s\n' %self.status
+            s += 'Result: {0!s}\n'.format(self.status)
 
         return s
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:scaramallion:pynetdicom3?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:scaramallion:pynetdicom3?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)